### PR TITLE
38 gaussian models volumetric correction

### DIFF
--- a/docs/src/equation_sets.md
+++ b/docs/src/equation_sets.md
@@ -38,11 +38,11 @@ u0, z0 = 1, 1
 zs = 0:.1:10
 
 for class in [ClassA,ClassB,ClassC,ClassD,ClassE,ClassF]
-    p = plot(title="Windspeed for $class stability",ylabel="Relative Elevation (z/z_R)", xlabel="Relative Windspeed (u/u_R)")
+    p = plot(title="Windspeed for $class stability",xlabel="Relative Elevation (z/z_R)", ylabel="Relative Windspeed (u/u_R)")
 
     for eqn in [DefaultSet,CCPSRural,CCPSUrban,ISC3Rural,ISC3Urban]
         u = [ GasDispersion._windspeed(u0,z0,z,class,eqn) for z in zs ]
-        plot!(p,zs,u,label=eqn)
+        plot!(p,u,zs,label=eqn)
     end
 
     savefig(p,"$(class)_windspeed.svg")

--- a/docs/src/plume.md
+++ b/docs/src/plume.md
@@ -21,21 +21,21 @@ The concentration is then given by:
 
 ```math
 
- c = {Q_i \over 2 \pi u \sigma_{y} \sigma_{z} }
+ c = {m_i \over 2 \pi u \sigma_{y} \sigma_{z} }
 \exp \left[ -\frac{1}{2} \left( y \over \sigma_{y} \right)^2 \right]
 \left\{ \exp \left[ -\frac{1}{2} \left( { z -h } \over \sigma_{z} \right)^2 \right] + \exp \left[ -\frac{1}{2} \left( { z + h } \over \sigma_{z} \right)^2 \right] \right\} 
 
 ```
 
 with
--  $c$  - concentration, volume fraction
--  $Q_i$  - volumetric emission rate of the species, m^3/s
+-  $c$  - concentration, kg/m^3
+-  $m_i$  - mass emission rate of the species, kg/s
 - *u* - windspeed, m/s
 -  $\sigma_y$  - crosswind dispersion, m
 -  $\sigma_z$  - vertical dispersion, m
 - *h* - release elevation, m
 
-Three important parameters are determined from correlations, which are functions of the atmospheric stability: the windspeed at the release point, the crosswind dispersion, and the vertical dispersion.
+Three important parameters are determined from correlations, which are functions of the atmospheric stability: the windspeed at the release point, the crosswind dispersion, and the vertical dispersion. The model converts the final concentration to volume fraction, assuming the plume is a gas at ambient conditions.
 
 ### Crosswind dispersion correlations
 
@@ -151,7 +151,7 @@ g = plume(scn, GaussianPlume)
 
 # output
 
-GasDispersion.GaussianPlumeSolution{Float64, GasDispersion.NoPlumeRise, ClassF, DefaultSet}(Scenario{Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}, HorizontalJet{Float64}, SimpleAtmosphere{Float64, ClassF}}(Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}("propane", 0.044096, GasDispersion.Antoine{Float64}(9.773719865868816, 2257.9247634130143, 0.0), 1.864931992847327, 526.13, 288.15, 101325.0, 1.142, 231.02, 425740, 1678, 2520), HorizontalJet{Float64}(0.08991798763471508, Inf, 0.01, 208.10961399327573, 3.5, 288765.2212333958, 278.3846872082166, 0.0), SimpleAtmosphere{Float64, ClassF}(101325.0, 298.15, 1.5, 10.0, 0.0, ClassF)), :gaussian, 0.9999999999999998, 0.01634489086156706, 1.150112899011524, 3.5, GasDispersion.NoPlumeRise(), ClassF, DefaultSet)
+GasDispersion.GaussianPlumeSolution{Float64, GasDispersion.NoPlumeRise, ClassF, DefaultSet}(Scenario{Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}, HorizontalJet{Float64}, SimpleAtmosphere{Float64, ClassF}}(Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}("propane", 0.044096, GasDispersion.Antoine{Float64}(9.773719865868816, 2257.9247634130143, 0.0), 1.864931992847327, 526.13, 288.15, 101325.0, 1.142, 231.02, 425740, 1678, 2520), HorizontalJet{Float64}(0.08991798763471508, Inf, 0.01, 208.10961399327573, 3.5, 288765.2212333958, 278.3846872082166, 0.0), SimpleAtmosphere{Float64, ClassF}(101325.0, 298.15, 1.5, 10.0, 0.0, ClassF)), :gaussian, 0.08991798763471508, 0.9999999999999998, 1.8023818673116125, 1.150112899011524, 3.5, GasDispersion.NoPlumeRise(), ClassF, DefaultSet)
 
 ```
 
@@ -162,11 +162,11 @@ g(100,0,2)
 
 # output
 
-0.0002006455298894473
+0.0006124169932080678
 
 ```
 
-Which is ~200ppm (vol). Beyond simply having a number, we may want a plan-view of the plume at a given height, say 2m.
+Which is ~612ppm (vol). Beyond simply having a number, we may want a plan-view of the plume at a given height, say 2m.
 
 ```@setup gaussplume
 using ..GasDispersion

--- a/docs/src/puff.md
+++ b/docs/src/puff.md
@@ -15,22 +15,22 @@ puff(::Scenario, ::Type{GaussianPuff})
 A gaussian puff model assumes the release is instantaneous, and all mass is concentrated in a single point. The cloud then disperses as it moves downwind with the concentration profile is given by a series of gaussians with dispersions $\sigma_x$, $\sigma_y$, and $\sigma_z$, which are found from correlations tabulated per stability class. Similarly to the plume model, a ground reflection term is included to correct for the fact that material cannot pass through the ground.
 
 ```math
-c_{puff} = { V_i \over { (2 \pi)^{3/2} \sigma_x \sigma_y \sigma_z } } 
+c_{puff} = { m_i \over { (2 \pi)^{3/2} \sigma_x \sigma_y \sigma_z } } 
 \exp \left( -\frac{1}{2} \left( {x - ut} \over \sigma_x \right)^2 \right) 
 \exp \left( -\frac{1}{2} \left( {y} \over \sigma_y \right)^2 \right)  \left[ \exp \left( -\frac{1}{2} \left( {z - h} \over \sigma_z \right)^2 \right) 
 + \exp \left( -\frac{1}{2} \left( {z + h} \over \sigma_z \right)^2 \right)\right]
 ```
 
 with
-- *c* - concentration, volume fraction
--  $V_i$ - volume of released material, m^3
+- *c* - concentration, kg/m^3
+-  $m_i$ - mass of released material, kg
 - *u* - windspeed, m/s
 -  $\sigma_x$  - downwind dispersion, m
 -  $\sigma_y$  - crosswind dispersion, m
 -  $\sigma_z$  - vertical dispersion, m
 - *h* - release elevation, m
 
-The model assumes the initial release is a single point, with no dimensions. Unlike the plume model, this concentration is a function of time.
+The model assumes the initial release is a single point, with no dimensions. Unlike the plume model, this concentration is a function of time. The model converts the final concentration to volume fraction, assuming the puff is a gas at ambient conditions.
 
 ### Downwind dispersion correlations
 
@@ -153,7 +153,7 @@ g = puff(scn, GaussianPuff)
 
 # output
 
-GasDispersion.GaussianPuffSolution{Float64, ClassF, DefaultSet}(Scenario{Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}, HorizontalJet{Float64}, SimpleAtmosphere{Float64, ClassF}}(Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}("propane", 0.044096, GasDispersion.Antoine{Float64}(9.773719865868816, 2257.9247634130143, 0.0), 1.864931992847327, 526.13, 288.15, 101325.0, 1.142, 231.02, 425740, 1678, 2520), HorizontalJet{Float64}(0.08991798763471508, 10.0, 0.01, 208.10961399327573, 3.5, 288765.2212333958, 278.3846872082166, 0.0), SimpleAtmosphere{Float64, ClassF}(101325.0, 298.15, 1.5, 10.0, 0.0, ClassF)), :gaussian, 0.16344890861567063, 3.5, 1.150112899011524, ClassF, DefaultSet)
+GasDispersion.GaussianPuffSolution{Float64, ClassF, DefaultSet}(Scenario{Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}, HorizontalJet{Float64}, SimpleAtmosphere{Float64, ClassF}}(Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}("propane", 0.044096, GasDispersion.Antoine{Float64}(9.773719865868816, 2257.9247634130143, 0.0), 1.864931992847327, 526.13, 288.15, 101325.0, 1.142, 231.02, 425740, 1678, 2520), HorizontalJet{Float64}(0.08991798763471508, 10.0, 0.01, 208.10961399327573, 3.5, 288765.2212333958, 278.3846872082166, 0.0), SimpleAtmosphere{Float64, ClassF}(101325.0, 298.15, 1.5, 10.0, 0.0, ClassF)), :gaussian, 0.8991798763471508, 1.8023818673116125, 3.5, 1.150112899011524, ClassF, DefaultSet)
 
 ```
 
@@ -164,7 +164,7 @@ g(100,0,2,86)
 
 # output
 
-0.0011119744194086872
+0.003394005492341503
 
 ```
 
@@ -211,7 +211,7 @@ t = 86
 
 @gif for t′ in range(0.85*t,1.15*t, length=50)
 
-plot(g, t′; xlims=(85,115), ylims=(-10,10), clims=(0,1.5e-3), aspect_ratio=:equal)
+plot(g, t′; xlims=(85,115), ylims=(-10,10), clims=(0,5e-3), aspect_ratio=:equal)
     
 end
 ```
@@ -226,19 +226,21 @@ puff(::Scenario, ::Type{IntPuff})
 The `IntPuff` model treats a release as a sequence of $n$ gaussian puffs, each one corresponding to $\frac{1}{n}$ of the total mass of the release.
 
 ```math
-c\left(x,y,z,t\right) = \sum_{i}^{n-1} { {Q_i \Delta t} \over n } { { \exp \left( -\frac{1}{2} \left( {x - u \left( t - i \delta t \right) } \over \sigma_x \right)^2 \right) } \over { \sqrt{2\pi} \sigma_x } } { { \exp \left( -\frac{1}{2} \left( {y} \over \sigma_y \right)^2 \right) } \over { \sqrt{2\pi} \sigma_y } }\\ \times { { \exp \left( -\frac{1}{2} \left( {z - h} \over \sigma_z \right)^2 \right) + \exp \left( -\frac{1}{2} \left( {z + h} \over \sigma_z \right)^2 \right) } \over { \sqrt{2\pi} \sigma_z } }
+c\left(x,y,z,t\right) = \sum_{i}^{n-1} { {m_i \Delta t} \over n } { { \exp \left( -\frac{1}{2} \left( {x - u \left( t - i \delta t \right) } \over \sigma_x \right)^2 \right) } \over { \sqrt{2\pi} \sigma_x } } { { \exp \left( -\frac{1}{2} \left( {y} \over \sigma_y \right)^2 \right) } \over { \sqrt{2\pi} \sigma_y } }\\ \times { { \exp \left( -\frac{1}{2} \left( {z - h} \over \sigma_z \right)^2 \right) + \exp \left( -\frac{1}{2} \left( {z + h} \over \sigma_z \right)^2 \right) } \over { \sqrt{2\pi} \sigma_z } }
 ```
 
 
 with 
-- *c* - concentration, volume fraction
--  $Q_i$ - emission rate, m^3/s
+- *c* - concentration, kg/m^3
+-  $m_i$ - emission rate, kg/s
 -  $\Delta t$ - total duration, s
 -  $ \delta t = {\Delta t \over n} $ - puff interval, s
 - *u* - windspeed, m/s
 -  $\sigma_x$ - downwind dispersion, m
 -  $\sigma_y$ - crosswind dispersion, m
 -  $\sigma_z$ - downwind dispersion, m
+
+The model assumes the initial release is a single point, with no dimensions. Additionally, model converts the final concentration to volume fraction, assuming the puff is a gas at ambient conditions.
 
 ### Dispersion Parameters
 
@@ -254,7 +256,7 @@ ig = puff(scn, IntPuff; n=100)
 
 # output
 
-GasDispersion.IntPuffSolution{Float64, Int64, ClassF, DefaultSet}(Scenario{Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}, HorizontalJet{Float64}, SimpleAtmosphere{Float64, ClassF}}(Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}("propane", 0.044096, GasDispersion.Antoine{Float64}(9.773719865868816, 2257.9247634130143, 0.0), 1.864931992847327, 526.13, 288.15, 101325.0, 1.142, 231.02, 425740, 1678, 2520), HorizontalJet{Float64}(0.08991798763471508, 10.0, 0.01, 208.10961399327573, 3.5, 288765.2212333958, 278.3846872082166, 0.0), SimpleAtmosphere{Float64, ClassF}(101325.0, 298.15, 1.5, 10.0, 0.0, ClassF)), :intpuff, 0.01634489086156706, 10.0, 3.5, 1.150112899011524, 100, ClassF, DefaultSet)
+GasDispersion.IntPuffSolution{Float64, Int64, ClassF, DefaultSet}(Scenario{Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}, HorizontalJet{Float64}, SimpleAtmosphere{Float64, ClassF}}(Substance{String, GasDispersion.Antoine{Float64}, Float64, Float64, Float64, Int64, Int64, Int64}("propane", 0.044096, GasDispersion.Antoine{Float64}(9.773719865868816, 2257.9247634130143, 0.0), 1.864931992847327, 526.13, 288.15, 101325.0, 1.142, 231.02, 425740, 1678, 2520), HorizontalJet{Float64}(0.08991798763471508, 10.0, 0.01, 208.10961399327573, 3.5, 288765.2212333958, 278.3846872082166, 0.0), SimpleAtmosphere{Float64, ClassF}(101325.0, 298.15, 1.5, 10.0, 0.0, ClassF)), :intpuff, 0.08991798763471508, 1.8023818673116125, 10.0, 3.5, 1.150112899011524, 100, ClassF, DefaultSet)
 ```
 
 At the same point as above the concentration has dropped
@@ -263,7 +265,7 @@ ig(100,0,2,86)
 
 # output
 
-8.260636961901386e-5
+0.0002521339225936648
 
 ```
 

--- a/src/models/gaussian_plume.jl
+++ b/src/models/gaussian_plume.jl
@@ -169,10 +169,7 @@ function (g::GaussianPlumeSolution{F,NoPlumeRise,S,E})(x, y, z, t=0) where {F<:N
 
         # c is in kg/m^3
         # use density at ambient conditions to convert to vol pct
-        T_a = _atmosphere_temperature(g.scenario)
-        P_a = _atmosphere_pressure(g.scenario)
-        ρ = _gas_density(g.scenario.substance,T_a,P_a)
-        c_vol = c/ρ
+        c_vol = c/g.mass_to_vol
 
         return min(c_vol,g.max_concentration)
     end
@@ -203,10 +200,7 @@ function (g::GaussianPlumeSolution{F,<:BriggsModel,S,E})(x, y, z, t=0) where {F<
 
         # c is in kg/m^3
         # use density at ambient conditions to convert to vol pct
-        T_a = _atmosphere_temperature(g.scenario)
-        P_a = _atmosphere_pressure(g.scenario)
-        ρ = _gas_density(g.scenario.substance,T_a,P_a)
-        c_vol = c/ρ
+        c_vol = c/g.mass_to_vol
 
         return min(c_vol,g.max_concentration)
     end

--- a/src/models/gaussian_plume.jl
+++ b/src/models/gaussian_plume.jl
@@ -5,15 +5,16 @@ struct GaussianPlume <: PlumeModel end
 struct GaussianPlumeSolution{F<:Number,P<:PlumeRise,S<:StabilityClass,E<:EquationSet} <: Plume
     scenario::Scenario
     model::Symbol
-    max_concentration::F
     rate::F
+    max_concentration::F
+    mass_to_vol::F
     windspeed::F
     effective_stack_height::F
     plumerise::P
     stability::Type{S}
     equationset::Type{E}
 end
-GaussianPlumeSolution(s,m,c_max,Q,u,h_eff,pr,stab,es) = GaussianPlumeSolution(s,m,promote(c_max,Q,u,h_eff)...,pr,stab,es)
+GaussianPlumeSolution(s,m,Q,c,ρ,u,h_eff,pr,stab,es) = GaussianPlumeSolution(s,m,promote(Q,c,ρ,u,h_eff)...,pr,stab,es)
 
 @doc doc"""
     plume(::Scenario, GaussianPlume[, ::EquationSet]; kwargs...)
@@ -21,7 +22,7 @@ GaussianPlumeSolution(s,m,c_max,Q,u,h_eff,pr,stab,es) = GaussianPlumeSolution(s,
 Returns the solution to a Gaussian plume dispersion model for the given scenario.
 
 ```math
-c\left(x,y,z\right) = {Q_{i} \over { 2 \pi \sigma_{y} \sigma_{z} u } }
+c\left(x,y,z\right) = {m_{i} \over { 2 \pi \sigma_{y} \sigma_{z} u } }
 \exp \left[ -\frac{1}{2} \left( y \over \sigma_{y} \right)^2 \right] \\
 \times \left\{ \exp \left[ -\frac{1}{2} \left( { z -h } \over \sigma_{z} \right)^2 \right]
 + \exp \left[ -\frac{1}{2} \left( { z + h } \over \sigma_{z} \right)^2 \right] \right\}
@@ -29,7 +30,8 @@ c\left(x,y,z\right) = {Q_{i} \over { 2 \pi \sigma_{y} \sigma_{z} u } }
 
 where the σs are dispersion parameters correlated with the distance x. The 
 `EquationSet` defines the set of correlations used to calculate the dispersion 
-parameters.
+parameters. The concentration returned is in volume fraction, assuming the plume 
+is a gas at ambient conditions.
 
 # References
 + AIChE/CCPS. 1999. *Guidelines for Consequence Analysis of Chemical Releases*. New York: American Institute of Chemical Engineers
@@ -37,31 +39,32 @@ parameters.
 """
 function plume(scenario::Scenario, ::Type{GaussianPlume}, eqs=DefaultSet; h_min=1.0)
     # parameters of the jet
-    ṁ  = _mass_rate(scenario)
-    ρⱼ = _release_density(scenario)
-    Dⱼ = _release_diameter(scenario)
-    Qⱼ = _release_flowrate(scenario)
-    uⱼ = _release_velocity(scenario)
     hᵣ = _release_height(scenario)
+    m  = _mass_rate(scenario)
+    Q  = _release_flowrate(scenario)
+    ρⱼ = _release_density(scenario)
 
-    # parameters of the environment
-    u = _windspeed(scenario,max(hᵣ,h_min),eqs)
-    stab = _stability(scenario)
+    # jet at ambient conditions
+    Tₐ = _atmosphere_temperature(scenario)
+    Pₐ = _atmosphere_pressure(scenario)
+    ρₐ = _gas_density(scenario.substance,Tₐ,Pₐ)
+    Qᵒ = Q*ρⱼ/ρₐ
 
     # max concentration
-    Qi = ṁ/ρⱼ
-    c_max = min(Qi/Qⱼ,1.0)
+    c_max = m/Qᵒ
+    c_max = c_max/ρₐ
 
     return GaussianPlumeSolution(
-    scenario, #scenario::Scenario
-    :gaussian, #model::Symbol
-    c_max, # max concentration
-    Qi,     #mass emission rate
-    u,     #windspeed
-    hᵣ,    #effective_stack_height::Number
-    NoPlumeRise(), #plume rise model
-    stab,  #stability class
-    eqs    #equation set 
+    scenario,                               # scenario::Scenario
+    :gaussian,                              # model::Symbol
+    m,                                      # mass emission rate
+    c_max,                                  # max_concentration
+    ρₐ,                                      # mass concentration to vol concentration
+    _windspeed(scenario,max(hᵣ,h_min),eqs), # windspeed
+    hᵣ,                                     # effective_stack_height::Number
+    NoPlumeRise(),                          # plume rise model
+    _stability(scenario),                   # stability class
+    eqs                                     # equation set 
     )
 end
 
@@ -72,7 +75,7 @@ Returns the solution to a Gaussian plume dispersion model for a vertical jet. By
 plume rise model is used.
 
 ```math
-c\left(x,y,z\right) = {Q_{i} \over { 2 \pi \sigma_{y} \sigma_{z} u } }
+c\left(x,y,z\right) = {m_{i} \over { 2 \pi \sigma_{y} \sigma_{z} u } }
 \exp \left[ -\frac{1}{2} \left( y \over \sigma_{y} \right)^2 \right] \\
 \times \left\{ \exp \left[ -\frac{1}{2} \left( { z -h } \over \sigma_{z} \right)^2 \right]
 + \exp \left[ -\frac{1}{2} \left( { z + h } \over \sigma_{z} \right)^2 \right] \right\}
@@ -80,7 +83,8 @@ c\left(x,y,z\right) = {Q_{i} \over { 2 \pi \sigma_{y} \sigma_{z} u } }
 
 where the σs are dispersion parameters correlated with the distance x. The 
 `EquationSet` defines the set of correlations used to calculate the dispersion 
-parameters.
+parameters. The concentration returned is in volume fraction, assuming the plume 
+is a gas at ambient conditions.
 
 # Arguments
 - `downwash::Bool=false`: when true, includes stack-downwash effects
@@ -91,23 +95,29 @@ parameters.
 + Briggs, Gary A. 1969. *Plume Rise* Oak Ridge: U.S. Atomic Energy Commission
 
 """
-function plume(scenario::Scenario{<:Substance,<:VerticalJet,<:Atmosphere}, ::Type{GaussianPlume}, eqs=DefaultSet; downwash::Bool=false, plumerise::Bool=true, h_min=1.0)
+function plume(scenario::Scenario{<:Substance,<:VerticalJet,<:Atmosphere}, ::Type{GaussianPlume}, eqs=DefaultSet; downwash::Bool=false, plumerise::Bool=true, h_min=1.0)  
     # parameters of the jet
-    ṁ  = _mass_rate(scenario)
-    ρⱼ = _release_density(scenario)
     Dⱼ = _release_diameter(scenario)
-    Qⱼ = _release_flowrate(scenario)
     uⱼ = _release_velocity(scenario)
     hᵣ = _release_height(scenario)
+    m  = _mass_rate(scenario)
+    Q  = _release_flowrate(scenario)
+    ρⱼ = _release_density(scenario)
 
     # parameters of the environment
     u = _windspeed(scenario,max(hᵣ,h_min),eqs)
     stab = _stability(scenario)
     Γ = _lapse_rate(scenario)
 
+    # jet at ambient conditions
+    Tₐ = _atmosphere_temperature(scenario)
+    Pₐ = _atmosphere_pressure(scenario)
+    ρₐ = _gas_density(scenario.substance,Tₐ,Pₐ)
+    Qᵒ = Q*ρⱼ/ρₐ
+
     # max concentration
-    Qi = ṁ/ρⱼ
-    c_max = min(Qi/Qⱼ,1.0)
+    c_max = m/Qᵒ
+    c_max = c_max/ρₐ
 
     # stack-tip downwash check
     if (downwash==true) && (uⱼ < 1.5*u)
@@ -121,7 +131,6 @@ function plume(scenario::Scenario{<:Substance,<:VerticalJet,<:Atmosphere}, ::Typ
     # plume rise
     if plumerise == true
         Tᵣ = _release_temperature(scenario)
-        Tₐ = _atmosphere_temperature(scenario)
         plume = plume_rise(Dⱼ,uⱼ,Tᵣ,u,Tₐ,Γ,stab)
     else
         plume = NoPlumeRise()
@@ -130,8 +139,9 @@ function plume(scenario::Scenario{<:Substance,<:VerticalJet,<:Atmosphere}, ::Typ
     return GaussianPlumeSolution(
     scenario, #scenario::Scenario
     :gaussian, #model::Symbol
-    c_max, # max concentration
-    Qi,     #mass emission rate
+    m,     #mass emission rate
+    c_max, #max concentration
+    ρₐ,    #mass to vol, at ambient conditions
     u,     #windspeed
     hᵣ,    #effective_stack_height::Number
     plume, #plume rise model
@@ -140,13 +150,13 @@ function plume(scenario::Scenario{<:Substance,<:VerticalJet,<:Atmosphere}, ::Typ
     )
 end
 
-function (g::GaussianPlumeSolution{<:Number,NoPlumeRise,S,E})(x, y, z, t=0) where {S<:StabilityClass,E<:EquationSet}
+function (g::GaussianPlumeSolution{F,NoPlumeRise,S,E})(x, y, z, t=0) where {F<:Number,S<:StabilityClass,E<:EquationSet}
     # domain check
     h = g.effective_stack_height
     if (x==0)&&(y==0)&&(z==h)
         return g.max_concentration
     elseif (x≤0)||(z<0)
-        return 0.0
+        return zero(F)
     else
         G = g.rate
         u = g.windspeed
@@ -157,17 +167,24 @@ function (g::GaussianPlumeSolution{<:Number,NoPlumeRise,S,E})(x, y, z, t=0) wher
             * exp(-0.5*(y/σy)^2)
             * ( exp(-0.5*((z-h)/σz)^2) + exp(-0.5*((z+h)/σz)^2) ) )
 
-        return min(g.max_concentration,c)
+        # c is in kg/m^3
+        # use density at ambient conditions to convert to vol pct
+        T_a = _atmosphere_temperature(g.scenario)
+        P_a = _atmosphere_pressure(g.scenario)
+        ρ = _gas_density(g.scenario.substance,T_a,P_a)
+        c_vol = c/ρ
+
+        return min(c_vol,g.max_concentration)
     end
 end
 
-function (g::GaussianPlumeSolution{<:Number,<:BriggsModel,S,E})(x, y, z, t=0) where {S<:StabilityClass,E<:EquationSet}
+function (g::GaussianPlumeSolution{F,<:BriggsModel,S,E})(x, y, z, t=0) where {F<:Number,S<:StabilityClass,E<:EquationSet}
     # domain check
     h = g.effective_stack_height
     if (x==0)&&(y==0)&&(z==h)
         return g.max_concentration
     elseif (x≤0)||(z<0)
-        return 0.0
+        return zero(F)
     else
         G = g.rate
         u = g.windspeed
@@ -184,6 +201,13 @@ function (g::GaussianPlumeSolution{<:Number,<:BriggsModel,S,E})(x, y, z, t=0) wh
             * exp(-0.5*(y/σyₑ)^2)
             * ( exp(-0.5*((z-hₑ)/σzₑ)^2) + exp(-0.5*((z+hₑ)/σzₑ)^2) ) )
 
-        return min(g.max_concentration,c)
+        # c is in kg/m^3
+        # use density at ambient conditions to convert to vol pct
+        T_a = _atmosphere_temperature(g.scenario)
+        P_a = _atmosphere_pressure(g.scenario)
+        ρ = _gas_density(g.scenario.substance,T_a,P_a)
+        c_vol = c/ρ
+
+        return min(c_vol,g.max_concentration)
     end
 end

--- a/test/models/britter_mcquaid_plume_tests.jl
+++ b/test/models/britter_mcquaid_plume_tests.jl
@@ -1,18 +1,17 @@
 @testset "Britter-McQuaid plume correlations" begin
-    include("../../src/utils/britter_mcquaid_correls.jl")
 
-    @test _bm_pl_c(-0.75)[2] ≈ [1.75, 1.92, 2.08, 2.25, 2.4, 2.6]
-    @test _bm_pl_c(-0.40)[2] ≈ [1.7839999999999998, 2.016, 2.21, 2.3939999999999997, 2.564, 2.714]
-    @test _bm_pl_c(-0.20)[2] ≈ [1.8319999999999999, 2.06, 2.25, 2.45, 2.63, 2.77]
-    @test _bm_pl_c(0.0)[2] ≈ [1.78, 1.96, 2.16, 2.35, 2.56, 2.71]
+    @test GasDispersion._bm_pl_c(-0.75)[2] ≈ [1.75, 1.92, 2.08, 2.25, 2.4, 2.6]
+    @test GasDispersion._bm_pl_c(-0.40)[2] ≈ [1.7839999999999998, 2.016, 2.21, 2.3939999999999997, 2.564, 2.714]
+    @test GasDispersion._bm_pl_c(-0.20)[2] ≈ [1.8319999999999999, 2.06, 2.25, 2.45, 2.63, 2.77]
+    @test GasDispersion._bm_pl_c(0.0)[2] ≈ [1.78, 1.96, 2.16, 2.35, 2.56, 2.71]
 
     # test domain warning
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pl_c_1(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pl_c_05(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pl_c_02(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pl_c_01(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pl_c_005(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pl_c_002(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pl_c_1(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pl_c_05(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pl_c_02(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pl_c_01(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pl_c_005(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pl_c_002(1.1)
 
 
 end

--- a/test/models/britter_mcquaid_puff_tests.jl
+++ b/test/models/britter_mcquaid_puff_tests.jl
@@ -1,18 +1,17 @@
 @testset "Britter-McQuaid puff correlations" begin
-    include("../../src/utils/britter_mcquaid_correls.jl")
 
-    @test _bm_pf_c(-0.75)[2] ≈ [0.7, 0.85, 0.95, 1.15, 1.48, 1.83, 2.075]
-    @test _bm_pf_c(0.0)[2] ≈ [0.81, 1.0, 1.19, 1.39, 1.62, 1.83, 2.05]
-    @test _bm_pf_c(0.75)[2] ≈ [0.93, 1.03, 1.1849999999999998, 1.375, 1.525, 1.68, 1.8474999999999997]
+    @test GasDispersion._bm_pf_c(-0.75)[2] ≈ [0.7, 0.85, 0.95, 1.15, 1.48, 1.83, 2.075]
+    @test GasDispersion._bm_pf_c(0.0)[2] ≈ [0.81, 1.0, 1.19, 1.39, 1.62, 1.83, 2.05]
+    @test GasDispersion._bm_pf_c(0.75)[2] ≈ [0.93, 1.03, 1.1849999999999998, 1.375, 1.525, 1.68, 1.8474999999999997]
 
     # test domain warning
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pf_c_1(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pf_c_05(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pf_c_02(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pf_c_01(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pf_c_005(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pf_c_002(1.1)
-    @test_logs (:warn, "α= 1.1 is out of range") _bm_pf_c_001(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pf_c_1(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pf_c_05(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pf_c_02(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pf_c_01(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pf_c_005(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pf_c_002(1.1)
+    @test_logs (:warn, "α= 1.1 is out of range") GasDispersion._bm_pf_c_001(1.1)
 
 end
 

--- a/test/models/gaussian_plume_tests.jl
+++ b/test/models/gaussian_plume_tests.jl
@@ -30,7 +30,7 @@
     pl = plume(scn)
 
     # test default behaviour and type inheritance
-    @test GasDispersion.GaussianPlumeSolution(scn,:test,1.0,2,3,4,GasDispersion.NoPlumeRise(),ClassA,DefaultSet) isa GasDispersion.GaussianPlumeSolution{Float64, GasDispersion.NoPlumeRise, ClassA, DefaultSet}
+    @test GasDispersion.GaussianPlumeSolution(scn,:test,1.0,2,3,4,5,GasDispersion.NoPlumeRise(),ClassA,DefaultSet) isa GasDispersion.GaussianPlumeSolution{Float64, GasDispersion.NoPlumeRise, ClassA, DefaultSet}
     @test pl isa GasDispersion.GaussianPlumeSolution
     @test pl isa Plume
     @test pl(-1,0,0) == 0.0

--- a/test/models/gaussian_puff_tests.jl
+++ b/test/models/gaussian_puff_tests.jl
@@ -36,7 +36,7 @@
     c₁ = 1/(√(2π)*π*σy^2*σz)/1.2268
 
     # test default behaviour and type inheritance
-    @test GasDispersion.GaussianPuffSolution(scn,:test_promotion,1.0,2,3,ClassA,DefaultSet) isa GasDispersion.GaussianPuffSolution{Float64, ClassA, DefaultSet}
+    @test GasDispersion.GaussianPuffSolution(scn,:test_promotion,1.0,2,3,4,ClassA,DefaultSet) isa GasDispersion.GaussianPuffSolution{Float64, ClassA, DefaultSet}
     @test pf isa GasDispersion.GaussianPuffSolution
     @test pf isa  Puff
     @test pf(x₁,0,0,-t₁) == 0.0

--- a/test/models/intpuff_tests.jl
+++ b/test/models/intpuff_tests.jl
@@ -29,7 +29,7 @@
     x₁, t₁, Δt, h = 500, 250, 10, 10
 
     # testing default behaviour
-    @test GasDispersion.IntPuffSolution(scn,:test_promotion,1.0,2,3,4,3,ClassA,DefaultSet) isa GasDispersion.IntPuffSolution{Float64, Int64, ClassA, DefaultSet}
+    @test GasDispersion.IntPuffSolution(scn,:test_promotion,1.0,2,3,4,5,6,ClassA,DefaultSet) isa GasDispersion.IntPuffSolution{Float64, Int64, ClassA, DefaultSet}
     @test puff(scn, IntPuff;n=1) isa GasDispersion.GaussianPuffSolution
     @test puff(scn, IntPuff;n=3) isa GasDispersion.IntPuffSolution{<:Number,<:Integer,<:StabilityClass,<:EquationSet}
     @test puff(scn, IntPuff) isa GasDispersion.IntPuffSolution{<:Number,<:Float64,<:StabilityClass,<:EquationSet}

--- a/test/utils/ccps_tests.jl
+++ b/test/utils/ccps_tests.jl
@@ -10,8 +10,8 @@
                  (ClassE, 0.13196833140024, 0.09591371646531512),
                  (ClassF, 0.13196833140024, 0.09591371646531512)]
         @testset "Plume dispersion, urban terrain, stability class $class" for (class,cwind,vert) in urban
-            @test crosswind_dispersion(1.2, Plume, class, CCPSUrban) ≈ cwind
-            @test vertical_dispersion(1.2, Plume, class, CCPSUrban) ≈ vert
+            @test GasDispersion.crosswind_dispersion(1.2, Plume, class, CCPSUrban) ≈ cwind
+            @test GasDispersion.vertical_dispersion(1.2, Plume, class, CCPSUrban) ≈ vert
         end
 
         rural = [(ClassA, 0.2639841614254575, 0.24),
@@ -21,8 +21,8 @@
                  (ClassE, 0.07199568038876113, 0.03598704466392099),
                  (ClassF, 0.04799712025917409, 0.019193090487424527)]
         @testset "Plume dispersion, rural terrain, stability class $class" for (class,cwind,vert) in rural
-            @test crosswind_dispersion(1.2, Plume, class, CCPSRural) ≈ cwind
-            @test vertical_dispersion(1.2, Plume, class, CCPSRural) ≈ vert
+            @test GasDispersion.crosswind_dispersion(1.2, Plume, class, CCPSRural) ≈ cwind
+            @test GasDispersion.vertical_dispersion(1.2, Plume, class, CCPSRural) ≈ vert
         end
 
         # Puff dispersion
@@ -33,9 +33,9 @@
                 (ClassE, 0.047304966328689864, 0.11258170198247626),
                 (ClassF, 0.023523465599668385, 0.05588182287353654)]
         @testset "Puff dispersion, stability class $class" for (class,cwind,vert) in knowns
-            @test crosswind_dispersion(1.2, Puff, class, CCPSUrban) ≈ cwind
-            @test downwind_dispersion(1.2, Puff, class, CCPSUrban) ≈ cwind
-            @test vertical_dispersion(1.2, Puff, class, CCPSUrban) ≈ vert
+            @test GasDispersion.crosswind_dispersion(1.2, Puff, class, CCPSUrban) ≈ cwind
+            @test GasDispersion.downwind_dispersion(1.2, Puff, class, CCPSUrban) ≈ cwind
+            @test GasDispersion.vertical_dispersion(1.2, Puff, class, CCPSUrban) ≈ vert
         end
     end
 
@@ -53,7 +53,7 @@
                  (ClassE, 7.53565929452874),
                  (ClassF, 11.943215116604916)]
         @testset "Windspeed, urban terrain, stability class $class" for (class, ans) in urban
-            @test  _windspeed(u0,z0,10,class,CCPSUrban) ≈ ans
+            @test  GasDispersion._windspeed(u0,z0,10,class,CCPSUrban) ≈ ans
         end
 
         rural = [(ClassA, 3.5246926648185886),
@@ -63,7 +63,7 @@
                  (ClassE, 6.716163415705019),
                  (ClassF, 10.644401677007265)]
         @testset "Windspeed, rural terrain, stability class $class" for (class, ans) in rural
-            @test  _windspeed(u0,z0,10,class,CCPSRural) ≈ ans
+            @test  GasDispersion._windspeed(u0,z0,10,class,CCPSRural) ≈ ans
         end
 
     end

--- a/test/utils/isc3_tests.jl
+++ b/test/utils/isc3_tests.jl
@@ -10,8 +10,8 @@
                  (ClassE, 0.13196833140024, 0.09591371646531512),
                  (ClassF, 0.13196833140024, 0.09591371646531512)]
         @testset "Plume dispersion, urban terrain, stability class $class" for (class,cwind,vert) in urban
-            @test crosswind_dispersion(1.2, Plume, class, ISC3Urban) ≈ cwind
-            @test vertical_dispersion(1.2, Plume, class, ISC3Urban) ≈ vert
+            @test GasDispersion.crosswind_dispersion(1.2, Plume, class, ISC3Urban) ≈ cwind
+            @test GasDispersion.vertical_dispersion(1.2, Plume, class, ISC3Urban) ≈ vert
         end
 
         rural = [(ClassA, 0.48870396813625905, [(50, 7.246283645973222), (125, 17.6538512508938), (175, 25.32210358392127), (225, 33.46114450376929), (275, 42.49832115580982), (350, 58.955561122372494), (450, 87.22955507375895), (550, 128.0454080208172)]),
@@ -21,9 +21,9 @@
                  (ClassE, 0.09742134712173195, [(50, 1.979015073784176), (200, 6.23857638464594), (500, 12.80138815568348), (1500, 27.931190340632067), (3000, 42.22135548587303), (7500, 68.37414410048738), (15000, 95.55830909365176), (30000, 127.31152395989899), (50000, 151.5410717370677)]),
                  (ClassF, 0.0645858766834503, [(100, 2.3255231110829815), (500, 8.395558503802999), (800, 11.976175562087187), (1500, 18.030377292486545), (2500, 24.42448141869856), (5000, 34.207199596890135), (10000, 46.38392157098271), (20000, 60.29440210746138), (45000, 76.93568233551231), (75000, 87.38876819912205)])]
         @testset "Plume dispersion, rural terrain, stability class $class" for (class,cwind,verts) in rural
-            @test crosswind_dispersion(1.2, Plume, class, ISC3Rural) ≈ cwind
+            @test GasDispersion.crosswind_dispersion(1.2, Plume, class, ISC3Rural) ≈ cwind
             for (x,sz) in verts
-                @test vertical_dispersion(x, Plume, class, ISC3Rural) ≈ sz
+                @test GasDispersion.vertical_dispersion(x, Plume, class, ISC3Rural) ≈ sz
             end
         end
 
@@ -43,7 +43,7 @@
                  (ClassE, 5.985786944906638),
                  (ClassF, 5.985786944906638)]
         @testset "Windspeed, urban terrain, stability class $class" for (class, ans) in urban
-            @test  _windspeed(u0,z0,10,class,ISC3Urban) ≈ ans
+            @test  GasDispersion._windspeed(u0,z0,10,class,ISC3Urban) ≈ ans
         end
 
         rural = [(ClassA, 3.5246926648185886),
@@ -53,7 +53,7 @@
                  (ClassE, 6.716163415705019),
                  (ClassF, 10.644401677007265)]
         @testset "Windspeed, rural terrain, stability class $class" for (class, ans) in rural
-            @test  _windspeed(u0,z0,10,class,ISC3Rural) ≈ ans
+            @test  GasDispersion._windspeed(u0,z0,10,class,ISC3Rural) ≈ ans
         end
 
     end

--- a/test/utils/tno_tests.jl
+++ b/test/utils/tno_tests.jl
@@ -10,8 +10,8 @@
                  (ClassE, 0.11551744100090941, 0.1713537324266559),
                  (ClassF, 0.07661871086795012, 0.135591567342651)]
         @testset "Plume dispersion, stability class $class" for (class,sy,sz) in known
-            @test crosswind_dispersion(1.2, Plume, class, TNO) ≈ sy
-            @test vertical_dispersion(1.2, Plume, class, TNO) ≈ sz
+            @test GasDispersion.crosswind_dispersion(1.2, Plume, class, TNO) ≈ sy
+            @test GasDispersion.vertical_dispersion(1.2, Plume, class, TNO) ≈ sz
         end
 
         # Puff dispersion
@@ -22,9 +22,9 @@
                  (ClassE, 0.057758720500454705, 0.18, 0.156),
                  (ClassF, 0.03830935543397506, 0.144, 0.156)]
        @testset "Puff dispersion, stability class $class" for (class,sy,sz,sx) in known
-            @test downwind_dispersion(1.2, Puff, class, TNO) ≈ sx
-            @test crosswind_dispersion(1.2, Puff, class, TNO) ≈ sy
-            @test vertical_dispersion(1.2, Puff, class, TNO) ≈ sz
+            @test GasDispersion.downwind_dispersion(1.2, Puff, class, TNO) ≈ sx
+            @test GasDispersion.crosswind_dispersion(1.2, Puff, class, TNO) ≈ sy
+            @test GasDispersion.vertical_dispersion(1.2, Puff, class, TNO) ≈ sz
        end
     end
 

--- a/test/utils/turner_tests.jl
+++ b/test/utils/turner_tests.jl
@@ -10,11 +10,11 @@
                  (ClassE, 0.10742276488910325, 0.09522313470055986, 4.156640589233231, 13.43619462405115, 346.73685045253166),
                  (ClassF, 0.07894741678277778, 0.0659507672737797, 2.625547335519663, 8.572359097689173, 106.16955571987263)]
         @testset "Plume dispersion, stability class $class" for (class,sy,sz1,sz2,sz3,sz4) in known
-            @test crosswind_dispersion(1.2, Plume, class, Turner) ≈ sy
-            @test vertical_dispersion(1.2, Plume, class, Turner) ≈ sz1
-            @test vertical_dispersion(120, Plume, class, Turner) ≈ sz2
-            @test vertical_dispersion(520, Plume, class, Turner) ≈ sz3
-            @test vertical_dispersion(1e6, Plume, class, Turner) ≈ sz4
+            @test GasDispersion.crosswind_dispersion(1.2, Plume, class, Turner) ≈ sy
+            @test GasDispersion.vertical_dispersion(1.2, Plume, class, Turner) ≈ sz1
+            @test GasDispersion.vertical_dispersion(120, Plume, class, Turner) ≈ sz2
+            @test GasDispersion.vertical_dispersion(520, Plume, class, Turner) ≈ sz3
+            @test GasDispersion.vertical_dispersion(1e6, Plume, class, Turner) ≈ sz4
         end
 
     end

--- a/test/utils/util_tests.jl
+++ b/test/utils/util_tests.jl
@@ -1,12 +1,11 @@
-include("../../src/utils/utils.jl")
 
 @testset "Monin-Obukhov length tests" begin
-    @test _monin_obukhov(1.2, ClassA) ≈ -11.609752888076077
-    @test _monin_obukhov(1.2, ClassB) ≈ -26.818480014823884
-    @test _monin_obukhov(1.2, ClassC) ≈ -129.91505611802876
-    @test _monin_obukhov(1.2, ClassD) == Inf
-    @test _monin_obukhov(1.2, ClassE) ≈ 129.91505611802876
-    @test _monin_obukhov(1.2, ClassF) ≈ 26.818480014823884
+    @test GasDispersion._monin_obukhov(1.2, ClassA) ≈ -11.609752888076077
+    @test GasDispersion._monin_obukhov(1.2, ClassB) ≈ -26.818480014823884
+    @test GasDispersion._monin_obukhov(1.2, ClassC) ≈ -129.91505611802876
+    @test GasDispersion._monin_obukhov(1.2, ClassD) == Inf
+    @test GasDispersion._monin_obukhov(1.2, ClassE) ≈ 129.91505611802876
+    @test GasDispersion._monin_obukhov(1.2, ClassF) ≈ 26.818480014823884
 end
 
 @testset "Pasquill-Gifford dispersion tests" begin
@@ -19,8 +18,8 @@ end
               (ClassE, 0.12018860465437811, 0.028796954615478678),
               (ClassF, 0.0794187446441675, 0.014462956106986533)]
     @testset "Stability class $class" for (class,cwind,vert) in knowns
-        @test crosswind_dispersion(1.2, Plume, class, DefaultSet()) ≈ cwind
-        @test vertical_dispersion(1.2, Plume, class, DefaultSet()) ≈ vert
+        @test GasDispersion.crosswind_dispersion(1.2, Plume, class, DefaultSet()) ≈ cwind
+        @test GasDispersion.vertical_dispersion(1.2, Plume, class, DefaultSet()) ≈ vert
     end
 
     # Puff dispersion
@@ -31,9 +30,9 @@ end
               (ClassE, 0.047304966328689864, 0.11258170198247626),
               (ClassF, 0.023523465599668385, 0.05588182287353654)]
     @testset "Stability class $class" for (class,cwind,vert) in knowns
-        @test crosswind_dispersion(1.2, Puff, class, DefaultSet()) ≈ cwind
-        @test downwind_dispersion(1.2, Puff, class, DefaultSet()) ≈ cwind
-        @test vertical_dispersion(1.2, Puff, class, DefaultSet()) ≈ vert
+        @test GasDispersion.crosswind_dispersion(1.2, Puff, class, DefaultSet()) ≈ cwind
+        @test GasDispersion.downwind_dispersion(1.2, Puff, class, DefaultSet()) ≈ cwind
+        @test GasDispersion.vertical_dispersion(1.2, Puff, class, DefaultSet()) ≈ vert
     end
 end
 
@@ -43,7 +42,7 @@ end
     a = SimpleAtmosphere(windspeed=u0, windspeed_height=z0, stability=ClassA)
     s = Scenario(Substance(:null,0,0,0,0,0,0,0,0,0,0,0),HorizontalJet(0,0,0,0,1.0,0,0,0),a)
     @test GasDispersion._windspeed(s) == GasDispersion._windspeed(a) ≈ u0
-    @test GasDispersion._windspeed(s,10) == GasDispersion._windspeed(a,10) == _windspeed(u0,z0,10,ClassA,DefaultSet())
+    @test GasDispersion._windspeed(s,10) == GasDispersion._windspeed(a,10) == GasDispersion._windspeed(u0,z0,10,ClassA,DefaultSet())
 
     knowns = [(ClassA, 3.846991747968065),
               (ClassB, 3.882587524349958),
@@ -53,26 +52,26 @@ end
               (ClassF, 5.371817562105883)]
 
     @testset "Stability class $class" for (class, ans) in knowns
-        @test  _windspeed(u0,z0,10,class,DefaultSet()) ≈ ans
+        @test  GasDispersion._windspeed(u0,z0,10,class,DefaultSet()) ≈ ans
     end
 
 end
 
 @testset "Windspeed by Monin-Obukhov length" begin
     ustar, zR, k = 3.0, 1.0, 0.35
-    λ = _monin_obukhov(zR, ClassA)
+    λ = GasDispersion._monin_obukhov(zR, ClassA)
     a(z) = (1-15*(z/λ))^0.25
     Ψ(a) = 2*log((1+a)/2) + log((1+a^2)/2) - 2*atan(a) + π/2
 
-    @test _windspeed(10, ustar, zR, λ, ClassA) ≈ (ustar/k)*(log((10+zR)/zR) - Ψ(a(10)))
-    @test _windspeed(10, ustar, zR, λ, ClassD) ≈ (ustar/k)*(log((10+zR)/zR))
-    @test _windspeed(10, ustar, zR, λ, ClassE) ≈ (ustar/k)*(log((10+zR)/zR) - 4.7*(10/λ))
+    @test GasDispersion._windspeed(10, ustar, zR, λ, ClassA) ≈ (ustar/k)*(log((10+zR)/zR) - Ψ(a(10)))
+    @test GasDispersion._windspeed(10, ustar, zR, λ, ClassD) ≈ (ustar/k)*(log((10+zR)/zR))
+    @test GasDispersion._windspeed(10, ustar, zR, λ, ClassE) ≈ (ustar/k)*(log((10+zR)/zR) - 4.7*(10/λ))
 end
 
 @testset "Plume rise" begin
 
     # test null case
-    @test isa(NoPlumeRise(),PlumeRise)
+    @test isa(GasDispersion.NoPlumeRise(),GasDispersion.PlumeRise)
 
     # test Briggs model of plume rise
     g = 9.80616 # m/s^2
@@ -86,19 +85,19 @@ end
     uⱼ = 72.93819699672669 # m/s
     xf = 565.0050541491846 # m
     Δhf = 100.71365158671999 # m
-    sln = plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0,ClassA)
-    @test isa(sln,BuoyantPlume)
-    @test sln ≈ BuoyantPlume(50,xf,u,Δhf)
-    @test plume_rise(x, sln) ≈ 20.0
-    @test plume_rise(2xf, sln) ≈ Δhf
+    sln = GasDispersion.plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0,ClassA)
+    @test isa(sln,GasDispersion.BuoyantPlume)
+    @test sln ≈ GasDispersion.BuoyantPlume(50,xf,u,Δhf)
+    @test GasDispersion.plume_rise(x, sln) ≈ 20.0
+    @test GasDispersion.plume_rise(2xf, sln) ≈ Δhf
 
     # Fb = 60 case
     uⱼ = 87.52583639607202
     xf = 612.07897481385
     Δhf = 112.8895989623143
-    sln = plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0,ClassA)
-    @test isa(sln,BuoyantPlume)
-    @test sln ≈ BuoyantPlume(60,xf,u,Δhf)
+    sln = GasDispersion.plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0,ClassA)
+    @test isa(sln,GasDispersion.BuoyantPlume)
+    @test sln ≈ GasDispersion.BuoyantPlume(60,xf,u,Δhf)
 
     # Momentum dominated unstable plume
     # Fb = 50 case
@@ -108,11 +107,11 @@ end
     Fm = 7171.814541070672
     β = (1/3) + (u/uⱼ)
     Δhf = 3*(uⱼ/u) # m
-    sln = plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0,ClassA)
-    @test isa(sln,MomentumPlume)
-    @test sln ≈ MomentumPlume(Fm,xf,β,u,0,Δhf,ClassA)
-    @test plume_rise(x, sln) ≈ 81.01824072514351
-    @test plume_rise(2xf, sln) ≈ Δhf
+    sln = GasDispersion.plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0,ClassA)
+    @test isa(sln,GasDispersion.MomentumPlume)
+    @test sln ≈ GasDispersion.MomentumPlume(Fm,xf,β,u,0,Δhf,ClassA)
+    @test GasDispersion.plume_rise(x, sln) ≈ 81.01824072514351
+    @test GasDispersion.plume_rise(2xf, sln) ≈ Δhf
 
     # Buoyant stable plume
     # Fb = 50, class E
@@ -120,18 +119,18 @@ end
     uⱼ = 72.93819699672669 # m/s
     xf = 317.60677324769046 # m
     Δhf = 68.59722859012221 # m
-    sln = plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0.02,ClassE)
-    @test isa(sln,BuoyantPlume)
-    @test sln ≈ BuoyantPlume(50,xf,u,Δhf)
+    sln = GasDispersion.plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0.02,ClassE)
+    @test isa(sln,GasDispersion.BuoyantPlume)
+    @test sln ≈ GasDispersion.BuoyantPlume(50,xf,u,Δhf)
 
     # Fb = 50, class F
     Tᵣ = 400 # K
     uⱼ = 72.93819699672669 # m/s
     xf = 240.0881533494489 # m
     Δhf = 56.92380039947288 # m
-    sln = plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0.035,ClassF)
-    @test isa(sln,BuoyantPlume)
-    @test sln ≈ BuoyantPlume(50,xf,u,Δhf)
+    sln = GasDispersion.plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0.035,ClassF)
+    @test isa(sln,GasDispersion.BuoyantPlume)
+    @test sln ≈ GasDispersion.BuoyantPlume(50,xf,u,Δhf)
 
     # Momentum dominated stable plume
     # Fb = 67, class E
@@ -142,11 +141,11 @@ end
     β = (1/3)+(u/uⱼ)
     s = 0.0006806288391462781
     Δhf = 19.04522445600697 # m
-    sln = plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0.02,ClassE)
-    @test isa(sln,MomentumPlume)
-    @test sln ≈ MomentumPlume(Fm,xf,β,u,s,Δhf,ClassE)
-    @test plume_rise(x, sln) ≈ Δhf
-    @test plume_rise(2xf, sln) ≈ Δhf
+    sln = GasDispersion.plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0.02,ClassE)
+    @test isa(sln,GasDispersion.MomentumPlume)
+    @test sln ≈ GasDispersion.MomentumPlume(Fm,xf,β,u,s,Δhf,ClassE)
+    @test GasDispersion.plume_rise(x, sln) ≈ Δhf
+    @test GasDispersion.plume_rise(2xf, sln) ≈ Δhf
 
     # Momentum dominated stable plume
     # Fb = 67, class F
@@ -157,9 +156,9 @@ end
     β = (1/3)+(u/uⱼ)
     s = 0.0011911004685059867
     Δhf = 17.349211998937378 # m
-    sln = plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0.035,ClassF)
-    @test isa(sln,MomentumPlume)
-    @test sln ≈ MomentumPlume(Fm,xf,β,u,s,Δhf,ClassF)
+    sln = GasDispersion.plume_rise(1,uⱼ,Tᵣ,u,Tₐ,0.035,ClassF)
+    @test isa(sln,GasDispersion.MomentumPlume)
+    @test sln ≈ GasDispersion.MomentumPlume(Fm,xf,β,u,s,Δhf,ClassF)
 
 end
 


### PR DESCRIPTION
Corrects plume volume concentrations for gaussian models. Assumes that the plume/puff is entirely at ambient conditions for the conversion from mass concentration to volume concentration.

Updated documentation to be more clear what is going on (and less clever): the mass concentration is calculated, per the reference, and the mass concentration is converted to vol fraction at the end, assuming a gas at ambient conditions.