### PR TITLE
Clapeyron package extension

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
           - Base
           - Util
           - Model
+          - Ext
           - Doc
         version:
           - '1.3'

--- a/Project.toml
+++ b/Project.toml
@@ -9,17 +9,17 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
-[weakdeps]
-Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
-
-[extras]
-Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
-
-[extensions]
-GasDispersionClapeyronExt = "Clapeyron"
-
 [compat]
 DataInterpolations = "3.6, 4, 6"
 RecipesBase = "1"
 SpecialFunctions = "2"
 julia = "1.3"
+
+[extensions]
+GasDispersionClapeyronExt = "Clapeyron"
+
+[extras]
+Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
+
+[weakdeps]
+Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,12 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
+[weakdeps]
+Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
+
+[extensions]
+GasDispersionClapeyronExt = "Clapeyron"
+
 [compat]
 DataInterpolations = "3.6, 4, 6"
 RecipesBase = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,9 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [weakdeps]
 Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
 
+[extras]
+Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
+
 [extensions]
 GasDispersionClapeyronExt = "Clapeyron"
 
@@ -19,4 +22,4 @@ GasDispersionClapeyronExt = "Clapeyron"
 DataInterpolations = "3.6, 4, 6"
 RecipesBase = "1"
 SpecialFunctions = "2"
-julia = "1"
+julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -9,17 +9,17 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
+[weakdeps]
+Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
+
+[extensions]
+GasDispersionClapeyronExt = "Clapeyron"
+
 [compat]
 DataInterpolations = "3.6, 4, 6"
 RecipesBase = "1"
 SpecialFunctions = "2"
 julia = "1.3"
 
-[extensions]
-GasDispersionClapeyronExt = "Clapeyron"
-
 [extras]
-Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
-
-[weakdeps]
 Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,21 @@ scn = scenario_builder(propane, JetSource;
 ```
 
 This generates a `Scenario` defined for a gas jet discharging into dry air
-at standard conditions. Once we have this defined we can determine the
+at standard conditions. 
+
+An alternative to supplying all of the substance properties, which can get
+rather onerous, is to use the library of substances and equations of state
+provided in [Clapeyron.jl](https://github.com/ClapeyronThermo/Clapeyron.jl)
+
+```julia
+using GasDispersion, Clapeyron
+
+propane = Substance(PropaneRef()) # uses an empirical EoS for propane
+
+propane = Substance(PR("propane"; idealmodel=ReidIdeal)) # uses the Peng-Robinson EoS
+```
+
+Once we have this defined we can determine the
 concentration at any point downwind of the release point, assuming the release
 is a continuous plume, using
 

--- a/docs/src/scenarios.md
+++ b/docs/src/scenarios.md
@@ -48,6 +48,26 @@ Substance: propane
 
 Note that the `Substance` has filled in some missing details. In particular it has calculateed the gas density `ρ_g`` at the reference point using the ideal gas law and has used the [Clausius-Clapeyron equation](https://en.wikipedia.org/wiki/Clausius%E2%80%93Clapeyron_relation) to derive a vapour pressure curve from the latent heat and the boiling temperature. It has also used a default value of 1.4 for [isentropic expansion factor](https://en.wikipedia.org/wiki/Heat_capacity_ratio)
 
+!!! note
+
+    A package extension exists for [Clapeyron.jl](https://github.com/ClapeyronThermo/Clapeyron.jl) that eliminates much of the hassle of creating `Substance`s. This requires julia >1.9 (it depends on the package extension feature) but allows one to create a `Substance` directly from a Clapeyron `EOSModel` object. For example, using the reference equation of state `PropaneRef()` from Clapeyron:
+
+    ```julia
+    using GasDispersion, Clapeyron
+
+    s = Substance(PropaneRef())
+
+    # output
+
+    GasDispersionClapeyronExt.ClapeyronSubstance: propane 
+        MW: 0.044095619999999995 kg/mol 
+        T_ref: 288.15 K 
+        P_ref: 101325.0 Pa 
+        k: 1.1416338312956256  
+        T_b: 231.03621464431782 K
+    ```
+    The other properties, such as vapor pressure and latent heat, are calculated on demand using the relevant routines from Clapeyron.
+
 In general several of the physical properties are functions of temperature and/or pressure, and they can be given as such. Since substances are re-usable, once defined they can be reused with many different scenarios, it may be worthwhile to find appropriate correlations for all of the physical and thermal properties of a substance. That said, it is not necessary.
 
 ### Vapor Pressure

--- a/ext/GasDispersionClapeyronExt.jl
+++ b/ext/GasDispersionClapeyronExt.jl
@@ -23,7 +23,11 @@ function ClapeyronSubstance(m::Clapeyron.EoSModel;reference_temp=288.15,referenc
     T_ref = reference_temp # K
     P_ref = reference_pressure # Pa
     T_b = Clapeyron.saturation_temperature(m,101325)[1] # Clapeyron [K] -> GasDispersion [K]
-    k = 1.4
+    
+    # adiabatic index
+    c_p = Clapeyron.isobaric_heat_capacity(m, P_ref, T_ref; phase=:gas)
+    c_v = Clapeyron.isochoric_heat_capacity(m, P_ref, T_ref; phase=:gas)
+    k = c_p/c_v
 
     return ClapeyronSubstance(name,m,promote(MW,T_ref,P_ref,k,T_b)...)
 end
@@ -51,10 +55,10 @@ end
 GasDispersion._MW(s::ClapeyronSubstance) = s.MW
 GasDispersion._vapor_pressure(s::ClapeyronSubstance, T) = Clapeyron.saturation_pressure(s.model, T)[1]
 
-GasDispersion._cp_gas(s::ClapeyronSubstance,T) = 0
+GasDispersion._cp_gas(s::ClapeyronSubstance,T) = Clapeyron.isobaric_heat_capacity(s.model, s.P_ref, T; phase=:gas)/s.MW #Clapeyron returns J/mol/K, expect J/kg/K
 GasDispersion._cp_gas(s::ClapeyronSubstance) = GasDispersion._cp_gas(s, s.T_ref)
 
-GasDispersion._cp_liquid(s::ClapeyronSubstance,T) = 0
+GasDispersion._cp_liquid(s::ClapeyronSubstance,T) = Clapeyron.isobaric_heat_capacity(s.model, s.P_ref, T; phase=:liquid)/s.MW #Clapeyron returns J/mol/K, expect J/kg/K
 GasDispersion._cp_liquid(s::ClapeyronSubstance) = GasDispersion._cp_liquid(s, s.T_ref)
 
 GasDispersion._boiling_temperature(s::ClapeyronSubstance) = s.T_b

--- a/ext/GasDispersionClapeyronExt.jl
+++ b/ext/GasDispersionClapeyronExt.jl
@@ -1,0 +1,82 @@
+module GasDispersionClapeyronExt
+
+using GasDispersion
+using Clapeyron
+
+struct ClapeyronSubstance{N<:Union{AbstractString,Symbol},M,F<:Number} <: AbstractSubstance
+    name::N
+    model::M
+    MW::F       # molar weight, kg/mol
+    T_ref::F    # reference temperature for densities, K (default 15°C)
+    P_ref::F    # reference pressure for densities, Pa (default 1atm)
+    k::F        # heat capacity ratio Cp/Cv, unitless (default 1.4)
+    T_b::F      # normal boiling point, K
+end
+
+function ClapeyronSubstance(m::Clapeyron.EoSModel;reference_temp=288.15,reference_pressure=101325)
+    if length(m.components) > 1
+        error("GasDispersion does not currently support multicomponent releases :(")
+    end
+
+    name = m.components[1] # I assume this is always a Vector{String}
+    MW = Clapeyron.mw(m)[1]/1000 # Clapeyron [g/mol] -> GasDispersion [kg/mol]
+    T_ref = reference_temp # K
+    P_ref = reference_pressure # Pa
+    T_b = Clapeyron.saturation_temperature(m,101325)[1] # Clapeyron [K] -> GasDispersion [K]
+    k = 1.4
+
+    return ClapeyronSubstance(name,m,promote(MW,T_ref,P_ref,k,T_b)...)
+end
+
+GasDispersion.Substance(m::Clapeyron.EoSModel;reference_temp=288.15,reference_pressure=101325) = ClapeyronSubstance(m;reference_temp=reference_temp,reference_pressure=reference_pressure)
+
+Base.isapprox(a::ClapeyronSubstance, b::ClapeyronSubstance) = all([
+    getproperty(a,k)≈getproperty(b,k) for k in fieldnames(typeof(a))
+    if typeof(getproperty(a,k))<:Number ])
+
+function Base.show(io::IO, mime::MIME"text/plain", s::S) where { S<:ClapeyronSubstance}
+    s_type = split(string(S),"{")[1]
+    print(io, "$s_type: $(s.name) \n")
+    for key in fieldnames(S) 
+        if key ∉ [:name,:model]
+            val =  getproperty(s, key)
+            var =  Symbol(split(string(key),"_")[1])
+            unit = GasDispersion.UNITS[var]
+            print(io, "    $key: $val $unit \n")
+        end
+    end
+end
+
+# ClapeyronSubstance property getters
+GasDispersion._MW(s::ClapeyronSubstance) = s.MW
+GasDispersion._vapor_pressure(s::ClapeyronSubstance, T) = Clapeyron.saturation_pressure(s.model, T)[1]
+
+GasDispersion._cp_gas(s::ClapeyronSubstance,T) = 0
+GasDispersion._cp_gas(s::ClapeyronSubstance) = GasDispersion._cp_gas(s, s.T_ref)
+
+GasDispersion._cp_liquid(s::ClapeyronSubstance,T) = 0
+GasDispersion._cp_liquid(s::ClapeyronSubstance) = GasDispersion._cp_liquid(s, s.T_ref)
+
+GasDispersion._boiling_temperature(s::ClapeyronSubstance) = s.T_b
+GasDispersion._latent_heat(s::ClapeyronSubstance,T) = Clapeyron.enthalpy_vap(s.model, T)/s.MW #Clapeyron returns J/mol, expect J/kg
+GasDispersion._latent_heat(s::ClapeyronSubstance) = GasDispersion._latent_heat(s, s.T_b)
+
+# density functions
+GasDispersion._liquid_density(s::ClapeyronSubstance, T, P) = Clapeyron.mass_density(s.model,P,T; phase=:liquid) # kg/m^3
+GasDispersion._liquid_density(s::ClapeyronSubstance) = GasDispersion._liquid_density(s, s.T_ref, s.P_ref)
+
+GasDispersion._gas_density(s::ClapeyronSubstance, T, P) = Clapeyron.mass_density(s.model,P,T; phase=:gas) # kg/m^3
+GasDispersion._gas_density(s::ClapeyronSubstance) = GasDispersion._gas_density(s, s.T_ref, s.P_ref)
+
+function GasDispersion._density(s::ClapeyronSubstance, f_l, T, P)
+    f_g = 1 - f_l
+    ρ_l = _liquid_density(s,T,P)
+    ρ_g = _gas_density(s,T,P)
+
+    return 1/(f_l/ρ_l + f_g/ρ_g)
+end
+
+
+
+
+end

--- a/src/GasDispersion.jl
+++ b/src/GasDispersion.jl
@@ -11,7 +11,7 @@ using RecipesBase
 # releases
 export Atmosphere, SimpleAtmosphere
 export StabilityClass, ClassA, ClassB, ClassC, ClassD, ClassE, ClassF
-export Substance
+export AbstractSubstance, Substance
 export Release, HorizontalJet, VerticalJet
 export Scenario, scenario_builder
 
@@ -31,6 +31,7 @@ export EquationSet, DefaultSet
 export CCPSRural, CCPSUrban, TNO, Turner, ISC3Rural, ISC3Urban
 
 # abstract types
+abstract type AbstractSubstance end
 abstract type Atmosphere end
 abstract type StabilityClass end
 abstract type Release end

--- a/src/base/base_types.jl
+++ b/src/base/base_types.jl
@@ -48,7 +48,7 @@ A simple container for the physical and thermal properties of substances.
 - `liquid_heat_capacity<:Union{Number,Function}`: the liquid heat capacity, J/kg/K.
 
 """
-struct Substance{N<:Union{AbstractString,Symbol},VAP<:CC,D_G<:CC,D_L<:CC,F<:Number,H<:CC,CP_G<:CC,CP_L<:CC}
+struct Substance{N<:Union{AbstractString,Symbol},VAP<:CC,D_G<:CC,D_L<:CC,F<:Number,H<:CC,CP_G<:CC,CP_L<:CC} <: AbstractSubstance
     name::N
     MW::F  # molar weight, kg/mol
     P_v::VAP    # vapour pressure, Pa
@@ -280,7 +280,7 @@ include("simple_atmosphere.jl")
 A chemical release scenario.
 
 """
-struct Scenario{S<:Substance,R<:Release,A<:Atmosphere}
+struct Scenario{S<:AbstractSubstance,R<:Release,A<:Atmosphere}
     substance::S
     release::R
     atmosphere::A

--- a/src/models/gaussian_plume.jl
+++ b/src/models/gaussian_plume.jl
@@ -69,7 +69,7 @@ function plume(scenario::Scenario, ::Type{GaussianPlume}, eqs=DefaultSet; h_min=
 end
 
 @doc doc"""
-    plume(::Scenario{Substance,VerticalJet,Atmosphere}, GaussianPlume[, ::EquationSet]; kwargs...)
+    plume(::Scenario{AbstractSubstance,VerticalJet,Atmosphere}, GaussianPlume[, ::EquationSet]; kwargs...)
 
 Returns the solution to a Gaussian plume dispersion model for a vertical jet. By default the Briggs
 plume rise model is used.
@@ -95,7 +95,7 @@ is a gas at ambient conditions.
 + Briggs, Gary A. 1969. *Plume Rise* Oak Ridge: U.S. Atomic Energy Commission
 
 """
-function plume(scenario::Scenario{<:Substance,<:VerticalJet,<:Atmosphere}, ::Type{GaussianPlume}, eqs=DefaultSet; downwash::Bool=false, plumerise::Bool=true, h_min=1.0)  
+function plume(scenario::Scenario{<:AbstractSubstance,<:VerticalJet,<:Atmosphere}, ::Type{GaussianPlume}, eqs=DefaultSet; downwash::Bool=false, plumerise::Bool=true, h_min=1.0)  
     # parameters of the jet
     Dⱼ = _release_diameter(scenario)
     uⱼ = _release_velocity(scenario)

--- a/src/source_models/jet_source.jl
+++ b/src/source_models/jet_source.jl
@@ -2,7 +2,7 @@
 struct JetSource <: SourceModel end
 
 @doc doc"""
-    scenario_builder(substance::Substance, JetSource, atmosphere::Atmosphere; kwargs...)
+    scenario_builder(substance::AbstractSubstance, JetSource, atmosphere::Atmosphere; kwargs...)
 Returns returns a scenario for a simple jet from a circular hole. The
 jet can either be a liquid or a gas (in which case it is assumed to be an ideal
 gas and the jet is isentropic).
@@ -20,7 +20,7 @@ gas and the jet is isentropic).
 - `duration::Number`: the duration of the leak, s
 
 """
-function scenario_builder(substance::Substance, ::Type{JetSource}, atmosphere::Atmosphere;
+function scenario_builder(substance::AbstractSubstance, ::Type{JetSource}, atmosphere::Atmosphere;
                           phase=:liquid,dischargecoef=0.63,diameter,pressure,temperature,height,duration=Inf)
     cd = dischargecoef
     d  = diameter

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,6 @@
 [deps]
-Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/test/exts/clapeyron_ext_tests.jl
+++ b/test/exts/clapeyron_ext_tests.jl
@@ -1,0 +1,25 @@
+using Clapeyron
+
+@testset "ClapeyronSubstance type" begin
+
+    ethylene = PR("ethylene")
+    sub = Substance(ethylene, reference_temp=169)
+    @test sub isa AbstractSubstance
+
+    @test sub.name == ethylene.components[1]
+
+    T,P = 169, 101325
+    MW = Clapeyron.mw(ethylene)[1]
+    @test GasDispersion._MW(sub) == MW/1000
+    @test GasDispersion._vapor_pressure(sub, T) ≈ Clapeyron.saturation_pressure(sub.model, T)[1]
+    @test GasDispersion._cp_gas(sub) ≈ GasDispersion._cp_gas(sub,T) ≈ 0
+    @test GasDispersion._cp_liquid(sub) ≈ GasDispersion._cp_liquid(sub,T) ≈ 0
+    @test GasDispersion._boiling_temperature(sub) ≈ Clapeyron.saturation_temperature(sub.model, 101325)[1]
+    @test GasDispersion._latent_heat(sub,T) ≈ Clapeyron.enthalpy_vap(sub.model, T)*1000/MW
+    @test GasDispersion._latent_heat(sub) ≈ Clapeyron.enthalpy_vap(sub.model, sub.T_b)*1000/MW
+
+    # density functions
+    @test GasDispersion._liquid_density(sub) ≈ GasDispersion._liquid_density(sub, T, P) ≈ Clapeyron.mass_density(sub.model,P,T; phase=:liquid)
+    @test GasDispersion._gas_density(sub) ≈ GasDispersion._gas_density(sub, T, P) ≈ Clapeyron.mass_density(sub.model,P,T; phase=:gas)
+
+end

--- a/test/exts/clapeyron_ext_tests.jl
+++ b/test/exts/clapeyron_ext_tests.jl
@@ -9,15 +9,15 @@
     T,P = 169, 101325
     MW = Clapeyron.mw(ethylene)[1]
     @test GasDispersion._MW(sub) == MW/1000
-    @test GasDispersion._vapor_pressure(sub, T) ≈ Clapeyron.saturation_pressure(sub.model, T)[1]
-    @test GasDispersion._cp_gas(sub) ≈ GasDispersion._cp_gas(sub,T) ≈ 0
-    @test GasDispersion._cp_liquid(sub) ≈ GasDispersion._cp_liquid(sub,T) ≈ 0
-    @test GasDispersion._boiling_temperature(sub) ≈ Clapeyron.saturation_temperature(sub.model, 101325)[1]
-    @test GasDispersion._latent_heat(sub,T) ≈ Clapeyron.enthalpy_vap(sub.model, T)*1000/MW
-    @test GasDispersion._latent_heat(sub) ≈ Clapeyron.enthalpy_vap(sub.model, sub.T_b)*1000/MW
+    @test GasDispersion._vapor_pressure(sub, T) ≈ Clapeyron.saturation_pressure(ethylene, T)[1]
+    @test GasDispersion._cp_gas(sub) ≈ GasDispersion._cp_gas(sub,T) ≈ Clapeyron.isobaric_heat_capacity(ethylene, P, T; phase=:gas)*1000/MW
+    @test GasDispersion._cp_liquid(sub) ≈ GasDispersion._cp_liquid(sub,T) ≈ Clapeyron.isobaric_heat_capacity(ethylene, P, T; phase=:liquid)*1000/MW
+    @test GasDispersion._boiling_temperature(sub) ≈ Clapeyron.saturation_temperature(ethylene, 101325)[1]
+    @test GasDispersion._latent_heat(sub,T) ≈ Clapeyron.enthalpy_vap(ethylene, T)*1000/MW
+    @test GasDispersion._latent_heat(sub) ≈ Clapeyron.enthalpy_vap(ethylene, sub.T_b)*1000/MW
 
     # density functions
-    @test GasDispersion._liquid_density(sub) ≈ GasDispersion._liquid_density(sub, T, P) ≈ Clapeyron.mass_density(sub.model,P,T; phase=:liquid)
-    @test GasDispersion._gas_density(sub) ≈ GasDispersion._gas_density(sub, T, P) ≈ Clapeyron.mass_density(sub.model,P,T; phase=:gas)
+    @test GasDispersion._liquid_density(sub) ≈ GasDispersion._liquid_density(sub, T, P) ≈ Clapeyron.mass_density(ethylene,P,T; phase=:liquid)
+    @test GasDispersion._gas_density(sub) ≈ GasDispersion._gas_density(sub, T, P) ≈ Clapeyron.mass_density(ethylene,P,T; phase=:gas)
 
 end

--- a/test/exts/clapeyron_ext_tests.jl
+++ b/test/exts/clapeyron_ext_tests.jl
@@ -1,5 +1,3 @@
-using Clapeyron
-
 @testset "ClapeyronSubstance type" begin
 
     ethylene = PR("ethylene")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ if GROUP == "All" || GROUP == "Model"
     include("models/slab_tests.jl")
 end
 
-if GROUP == "All" || GROUP == "Extensions"
+if GROUP == "All" || GROUP == "Ext"
     #test clapeyron extension
     include("exts/clapeyron_ext_tests.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using Test, Documenter, GasDispersion
 using DelimitedFiles: readdlm
 
-const GROUP = get(ENV,"GROUP","All")
+# const GROUP = get(ENV,"GROUP","All")
+const GROUP = "Extensions"
 const VERSION = get(ENV,"VERSION","latest")
 
 if GROUP == "All" || GROUP == "Base"
@@ -36,6 +37,11 @@ if GROUP == "All" || GROUP == "Model"
     include("models/britter_mcquaid_plume_tests.jl")
     include("models/britter_mcquaid_puff_tests.jl")
     include("models/slab_tests.jl")
+end
+
+if GROUP == "All" || GROUP == "Extensions"
+    #test clapeyron extension
+    include("exts/clapeyron_ext_tests.jl")
 end
 
 # some doc tests don't work with julia 1.3, because of Documenter

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,8 +38,11 @@ if GROUP == "All" || GROUP == "Model"
     include("models/slab_tests.jl")
 end
 
-if GROUP == "All" || GROUP == "Ext"
-    #test clapeyron extension
+if GROUP ∈ ["All", "Ext"] && VERSION ∈ ["1","latest","nightly"]
+    # this feels kind of janky to me, but it stops versions <1.9
+    # from trying to run the Clapeyron extension
+    import Pkg; Pkg.add("Clapeyron")
+    using Clapeyron
     include("exts/clapeyron_ext_tests.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,7 @@
 using Test, Documenter, GasDispersion
 using DelimitedFiles: readdlm
 
-# const GROUP = get(ENV,"GROUP","All")
-const GROUP = "Extensions"
+const GROUP = get(ENV,"GROUP","All")
 const VERSION = get(ENV,"VERSION","latest")
 
 if GROUP == "All" || GROUP == "Base"


### PR DESCRIPTION
This extension allows one to use an `EoSModel` from Clapeyron as a `Substance` for release modeling.

Package extension is not reverse compatible, it only works for Julia >1.9.