### PR TITLE
Changed latent heat ref. temp to the normal boiling point

### DIFF
--- a/src/base/base_types.jl
+++ b/src/base/base_types.jl
@@ -77,7 +77,7 @@ function Substance(name,molar_weight,vapor_pressure,gas_density,liquid_density,
         if latent_heat isa Number
             Δh = latent_heat
         else
-            Δh = latent_heat(reference_temp)
+            Δh = latent_heat(boiling_temp)
         end
 
         B = Δh*molar_weight/R_GAS_CONST
@@ -131,7 +131,7 @@ _cp_liquid(s::Substance) = _cp_liquid(s, s.T_ref)
 _boiling_temperature(s::Substance) = s.T_b
 _latent_heat(s::Substance{<:Any,<:Any,<:Any,<:Any,<:Any,<:Number},T) = s.Δh_v
 _latent_heat(s::Substance{<:Any,<:Any,<:Any,<:Any,<:Any,<:CALLABLE},T) = s.Δh_v(T)
-_latent_heat(s::Substance) = _latent_heat(s, s.T_ref)
+_latent_heat(s::Substance) = _latent_heat(s, s.T_b)
 
 # density functions
 _liquid_density(s::Substance{<:Any,<:Any,<:Any,<:Number}, T::Number, P::Number) = s.ρ_l

--- a/test/base/base_types_tests.jl
+++ b/test/base/base_types_tests.jl
@@ -45,7 +45,7 @@ replstr(x, kv::Pair...) = sprint((io,x) -> show(IOContext(io, :limit => true, :d
     @test GasDispersion._liquid_density(propane) == GasDispersion._liquid_density(propane,288.15,101325) == ρl(288.15,101325) ≈ 506.61518872042035
     @test GasDispersion._gas_density(propane) == GasDispersion._gas_density(propane,288.15,101325) ≈ ρg
     @test GasDispersion._density(propane,0.5,288.15,101325) ≈ 2/(1/ρg + 1/506.61518872042035)
-    @test GasDispersion._latent_heat(propane) == GasDispersion._latent_heat(propane,288.15) == Δhv(288.15) ≈ 352233.34066640574
+    @test GasDispersion._latent_heat(propane) == GasDispersion._latent_heat(propane,231.02) == Δhv(231.02) ≈ 425139.0953430851
     @test GasDispersion._cp_gas(propane) == GasDispersion._cp_gas(propane,288.15) == cp_ig(288.15) ≈ 1618.86346283786
     @test GasDispersion._cp_liquid(propane) == GasDispersion._cp_liquid(propane,288.15) == cp_l(288.15) ≈ 2626.002694859999
 
@@ -65,7 +65,7 @@ replstr(x, kv::Pair...) = sprint((io,x) -> show(IOContext(io, :limit => true, :d
                         latent_heat=Δhv,
                         gas_heat_capacity=cp_ig,
                         liquid_heat_capacity=cp_l)
-    @test test_pv.P_v ≈ GasDispersion.Antoine(8.086226333190652, 1868.0800074937044, 0.0)
+    @test test_pv.P_v ≈ GasDispersion.Antoine(9.759924888223345, 2254.7378476773574, 0.0)
     
     test_pv2 = Substance(name="propane",
                          molar_weight=0.044096,

--- a/test/models/slab_tests.jl
+++ b/test/models/slab_tests.jl
@@ -31,7 +31,7 @@
                   liquid_density=ρl,reference_temp=288.15,reference_pressure=101325,k=1.3,
                   boiling_temp=231.02,latent_heat=Δhv,gas_heat_capacity=cp_ig,
                   liquid_heat_capacity=cp_l)
-    @test GasDispersion._slab_antoine(Scenario(s,r,SimpleAtmosphere(temperature=288.15))) ≈ GasDispersion.Antoine(8.086226333190652, 1868.0800074937044, 0.0)
+    @test GasDispersion._slab_antoine(Scenario(s,r,SimpleAtmosphere(temperature=288.15))) ≈ GasDispersion.Antoine(9.759924888223345, 2254.7378476773574, 0.0)
 
 end
 


### PR DESCRIPTION
Previously, the default temperature for the latent heat (when not otherwise specified) was the reference temperature for the substance. This is unexpected and can lead to weird behavior when the reference temperature of the substance is far from the two-phase region. Really, it should be the normal boiling point.

Correcting this also corrects a subtle error in the Clausius-Clapeyron -> Antoine Equation routine. The temperature used in the Clausius-Clapeyron equation to define one point on the vapour pressure curve is the normal boiling point, the latent heat should also be at this temperature for it to make sense.