### PR TITLE
Fixes to SLAB vertical jet

### DIFF
--- a/src/models/slab_puff.jl
+++ b/src/models/slab_puff.jl
@@ -168,14 +168,14 @@ function puff(scenario::Scenario{<:AbstractSubstance,<:VerticalJet,<:Atmosphere}
     xperm = sortperm(out.cc.x)
     tperm = sortperm(out.cc.t)
     return SLABSolution(scenario,:SLAB,inp,out,c_max,
-                        AkimaInterpolation(out.cc.cc, out.cc.x),
-                        AkimaInterpolation(out.cc.b, out.cc.x),
-                        AkimaInterpolation(out.cc.betac, out.cc.x),
-                        AkimaInterpolation(out.cc.zc, out.cc.x),
-                        AkimaInterpolation(out.cc.sig, out.cc.x),
-                        AkimaInterpolation(out.cc.xc, out.cc.t),
-                        AkimaInterpolation(out.cc.bx, out.cc.t),
-                        AkimaInterpolation(out.cc.betax, out.cc.t))
+                        AkimaInterpolation(out.cc.cc[xperm], out.cc.x[xperm]),
+                        AkimaInterpolation(out.cc.b[xperm], out.cc.x[xperm]),
+                        AkimaInterpolation(out.cc.betac[xperm], out.cc.x[xperm]),
+                        AkimaInterpolation(out.cc.zc[xperm], out.cc.x[xperm]),
+                        AkimaInterpolation(out.cc.sig[xperm], out.cc.x[xperm]),
+                        AkimaInterpolation(out.cc.xc[tperm], out.cc.t[tperm]),
+                        AkimaInterpolation(out.cc.bx[tperm], out.cc.t[tperm]),
+                        AkimaInterpolation(out.cc.betax[tperm], out.cc.t[tperm]))
 
 end
 

--- a/src/models/slab_puff.jl
+++ b/src/models/slab_puff.jl
@@ -128,7 +128,8 @@ function puff(scenario::Scenario, ::Type{SLAB}, eqs::EquationSet=DefaultSet();
                         AkimaInterpolation(out.cc.betax[tperm], out.cc.t[tperm]))
 end
 
-function puff(scenario::Scenario{<:AbstractSubstance,<:VerticalJet,<:Atmosphere}, ::Type{SLAB}, eqs::EquationSet=DefaultSet(); release_angle::Number=π/2, k2::Number=6.0, k3::Number=5.0)
+function puff(scenario::Scenario{<:AbstractSubstance,<:VerticalJet,<:Atmosphere}, ::Type{SLAB}, eqs::EquationSet=DefaultSet();
+              t_av=10, x_max=2000)
     c_max = 1.0
     stab = _slab_stab( _stability(scenario) )
     antoine = _slab_antoine(scenario)

--- a/test/models/slab_tests.jl
+++ b/test/models/slab_tests.jl
@@ -273,4 +273,46 @@ end
     @test result ≈ out[:, 1:23]
 end
 
+@testset "INPR4 Vertical Jet - z0 = 1.0" begin
+    # this tests against the INPR4 test problem, but with the surface _surface_roughness
+    # at the default value for a SimpleAtmosphere type, z0=1.0
+
+    s = Substance(
+        name="inpr4",
+        molar_weight=0.070906,
+        gas_heat_capacity=498.1,
+        boiling_temp=239.1,
+        latent_heat=287840.0,
+        liquid_heat_capacity=926.3,
+        liquid_density=1574.0,
+        vapor_pressure=GasDispersion.Antoine(0,1978.34,-27.01)
+    )
+    r = VerticalJet(
+        fraction_liquid=0.88,
+        temperature=239.1,
+        mass_rate=3.33,
+        diameter=√(4*0.02/π),
+        duration=300.0,
+        height=1.0,
+        velocity=0.0,
+        pressure=101325
+    )
+
+    a = SimpleAtmosphere(
+        windspeed_height=10.0,
+        windspeed=1.0,
+        temperature=276.0,
+        rel_humidity=30.0,
+        stability=ClassD
+    )
+    tav = 1.0
+    xffm = 10000.0
+
+    inpr4 = Scenario(s,r,a)
+    rls = puff(inpr4, SLAB; t_av=tav, x_max=xffm)
+
+    @test rls.betax(17423.2) ≈ 4103.183379580039
+
+end
+
 end


### PR DESCRIPTION
When SLAB transitions from steady state to transient it is possible to have two rows out of order, i.e. it appears to step backwards in time momentarily. In the past DataInterpolations would warn about this, but since v8.0.1 it breaks. This fixes the issue for a VerticalJet release type.

Also added some missing integration tests for the SLAB VerticalJet.